### PR TITLE
Constraints feature

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -9,7 +9,7 @@ from .helpers import UtilityFunction, unique_rows, PrintLog, acq_max
 
 class BayesianOptimization(object):
 
-    def __init__(self, f, pbounds, constraints=({}), verbose=1):
+    def __init__(self, f, pbounds, constraints=None, verbose=1):
         """
         :param f:
             Function to be maximized.

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -9,7 +9,7 @@ from .helpers import UtilityFunction, unique_rows, PrintLog, acq_max
 
 class BayesianOptimization(object):
 
-    def __init__(self, f, pbounds, verbose=1):
+    def __init__(self, f, pbounds, constraints=({}), verbose=1):
         """
         :param f:
             Function to be maximized.
@@ -17,6 +17,9 @@ class BayesianOptimization(object):
         :param pbounds:
             Dictionary with parameters names as keys and a tuple with minimum
             and maximum values.
+        
+        :param constraints:
+            Tuple containing constraint dictionaries.
 
         :param verbose:
             Whether or not to print progress.
@@ -24,6 +27,9 @@ class BayesianOptimization(object):
         """
         # Store the original dictionary
         self.pbounds = pbounds
+        
+        # Store the constraints dictionary
+        self.constraints = constraints
 
         # Get the name of the parameters
         self.keys = list(pbounds.keys())
@@ -261,7 +267,8 @@ class BayesianOptimization(object):
         x_max = acq_max(ac=self.util.utility,
                         gp=self.gp,
                         y_max=y_max,
-                        bounds=self.bounds)
+                        bounds=self.bounds,
+                        constraints=self.constraints)
 
         # Print new header
         if self.verbose:
@@ -300,8 +307,8 @@ class BayesianOptimization(object):
             x_max = acq_max(ac=self.util.utility,
                             gp=self.gp,
                             y_max=y_max,
-                            bounds=self.bounds)
-
+                            bounds=self.bounds,
+                            constraints=self.constraints)
             # Print stuff
             if self.verbose:
                 self.plog.print_step(self.X[-1], self.Y[-1], warning=pwarning)

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -19,7 +19,8 @@ class BayesianOptimization(object):
             and maximum values.
         
         :param constraints:
-            Tuple containing constraint dictionaries.
+            Tuple containing constraint dictionaries, each of the form {'type':x, 'fun':y} 
+            where x is one of "eq" or "ineq" and y is a functinal form of the constraint.
 
         :param verbose:
             Whether or not to print progress.

--- a/bayes_opt/helpers.py
+++ b/bayes_opt/helpers.py
@@ -29,7 +29,7 @@ def acq_max(ac, gp, y_max, bounds, constraints):
         The variables bounds to limit the search of the acq max.
         
     :param constraints:
-        The tuple of constraints dictionaries, each of the form {'type':x, 'fun':y} where x is in ['ineq', 'eq'] and y is a functional representation of the constraint.
+        The tuple of constraints dictionaries.
 
 
     Returns

--- a/bayes_opt/helpers.py
+++ b/bayes_opt/helpers.py
@@ -45,7 +45,7 @@ def acq_max(ac, gp, y_max, bounds, constraints):
                                 size=(250, bounds.shape[0]))
     for x_try in x_seeds:
         # Find the minimum of minus the acquisition function
-        if len(constraints)>0:
+        if constraints:
             res = minimize(lambda x: -ac(x.reshape(1, -1), gp=gp, y_max=y_max),
                        x_try.reshape(1, -1),
                        bounds=bounds,

--- a/bayes_opt/helpers.py
+++ b/bayes_opt/helpers.py
@@ -6,7 +6,7 @@ from scipy.stats import norm
 from scipy.optimize import minimize
 
 
-def acq_max(ac, gp, y_max, bounds):
+def acq_max(ac, gp, y_max, bounds, constraints):
     """
     A function to find the maximum of the acquisition function
 
@@ -27,6 +27,9 @@ def acq_max(ac, gp, y_max, bounds):
 
     :param bounds:
         The variables bounds to limit the search of the acq max.
+        
+    :param constraints:
+        The tuple of constraints dictionaries, each of the form {'type':x, 'fun':y} where x is in ['ineq', 'eq'] and y is a functional representation of the constraint.
 
 
     Returns
@@ -34,28 +37,29 @@ def acq_max(ac, gp, y_max, bounds):
     :return: x_max, The arg max of the acquisition function.
     """
 
-    # Warm up with random points
-    x_tries = np.random.uniform(bounds[:, 0], bounds[:, 1],
-                                 size=(100000, bounds.shape[0]))
-    ys = ac(x_tries, gp=gp, y_max=y_max)
-    x_max = x_tries[ys.argmax()]
-    max_acq = ys.max()
+    x_max = None
+    max_acq = -float("Inf")
 
     # Explore the parameter space more throughly
     x_seeds = np.random.uniform(bounds[:, 0], bounds[:, 1],
                                 size=(250, bounds.shape[0]))
     for x_try in x_seeds:
         # Find the minimum of minus the acquisition function
-        res = minimize(lambda x: -ac(x.reshape(1, -1), gp=gp, y_max=y_max),
+        if len(constraints)>0:
+            res = minimize(lambda x: -ac(x.reshape(1, -1), gp=gp, y_max=y_max),
+                       x_try.reshape(1, -1),
+                       bounds=bounds,
+                       method="SLSQP",
+                       constraints=constraints)
+        else:
+            res = minimize(lambda x: -ac(x.reshape(1, -1), gp=gp, y_max=y_max),
                        x_try.reshape(1, -1),
                        bounds=bounds,
                        method="L-BFGS-B")
-
         # Store it if better than previous minimum(maximum).
         if max_acq is None or -res.fun[0] >= max_acq:
             x_max = res.x
             max_acq = -res.fun[0]
-
     # Clip output to make sure it lies within the bounds. Due to floating
     # point technicalities this is not always the case.
     return np.clip(x_max, bounds[:, 0], bounds[:, 1])


### PR DESCRIPTION
As per #44,  I've added a ``constraints`` parameter to the ``__init__`` method for the ``BayesianOptimization`` class.  I plan on adding a notebook in the examples folder detailing how to use the feature in a separate PR.

I had to delete the "warm up with random points" part of the ``acq_max`` function, as it allowed random searching outside of the constrained search space.  Another issue that came up was that initialization points increasingly do not satisfy the constraints as larger sections of the input space are cut out by the constraints.  The only obvious way to prevent this is to allow the user to input ``init_points = 0`` in the ``maximize`` method, however this isn't currently accommodated by the code.  I'll create a separate issue for this once this PR is merged.

@fmfn: feedback would be appreciated.