### PR TITLE
Update X and Y during init

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -105,7 +105,7 @@ class BayesianOptimization(object):
             self.Y = np.append(self.Y, self.f(**dict(zip(self.keys, x))))
 
             if self.verbose:
-                self.plog.print_step(x, y_init[-1])
+                self.plog.print_step(x, self.Y[-1])
 
         # Append any other points passed by the self.initialize method (these
         # also have a corresponding target value passed by the user).

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -94,14 +94,15 @@ class BayesianOptimization(object):
         # points from self.explore method.
         self.init_points += list(map(list, zip(*l)))
 
-        # Create empty list to store the new values of the function
-        y_init = []
+        # Create empty arrays to store the new points and values of the function.
+        self.X = np.empty((0, self.bounds.shape[0]))
+        self.Y = np.empty(0)
 
         # Evaluate target function at all initialization
         # points (random + explore)
         for x in self.init_points:
-
-            y_init.append(self.f(**dict(zip(self.keys, x))))
+            self.X = np.vstack((self.X, np.asarray(x).reshape((1, -1))))
+            self.Y = np.append(self.Y, self.f(**dict(zip(self.keys, x))))
 
             if self.verbose:
                 self.plog.print_step(x, y_init[-1])
@@ -109,13 +110,10 @@ class BayesianOptimization(object):
         # Append any other points passed by the self.initialize method (these
         # also have a corresponding target value passed by the user).
         self.init_points += self.x_init
+        self.X = np.vstack((self.X, np.asarray(self.x_init).reshape(-1, self.X.shape[1])))
 
         # Append the target value of self.initialize method.
-        y_init += self.y_init
-
-        # Turn it into np array and store.
-        self.X = np.asarray(self.init_points)
-        self.Y = np.asarray(y_init)
+        self.Y = np.concatenate((self.Y, self.y_init))
 
         # Updates the flag
         self.initialized = True


### PR DESCRIPTION
I often plot/monitor the optimisation each iteration in case I want to stop early or change some parameters. I do this by adding monitoring code to the target function.

Currently, the x and y values checked during `explore` and `init` are not accessible (stored on the `bo` object) until after both steps are complete, which can take a long time for expensive functions. 

This PR adds updates `self.X` and `self.Y` each iteration of the explore/init step. Most of the logic is converting `append` and `+=` to numpy equivalents. Adds a bit of complexity but doesn't change any other part of the API.

You could go all out and also update `bo.go.fit()` and `bo.res` each iteration, and add callback parameter 
 to be called after each iteration to avoid hacking the target function like xgboost and some sklearn functions. But just updating `X` and `Y` is the minimum info needed for a user to just do that themselves.

