### PR TITLE
explore_eager and new data structure for efficient appends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: python
+sudo: false
+
+cache:
+  apt: true
+  directories:
+  - $HOME/.cache/pip
+  - $HOME/download
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+before_install:
+  - pip install pip -U
+  - pip install pytest -U
+  - pip install pytest-cov -U
+  - pip install codecov -U
+  #- pip install xdoctest -U
+#  - pip install delorean
+install:
+  #- travis_retry python setup.py build develop
+  - travis_retry pip install -e .
+script: 
+  - travis_wait pytest --cov-config .coveragerc --cov-report html --cov bayes_opt bayes_opt
+    #-p no:doctest --xdoctest --cov=ubelt ubelt
+after_success: 
+  #- coveralls || echo "Coveralls upload failed"
+  - codecov 
+#after_failure: 
+#  - cat failed_doctests.txt
+cache: 
+    apt: true
+    directories:
+        - $HOME/.pip-cache

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -54,14 +54,15 @@ class BayesianOptimization(object):
         # Utility Function placeholder
         self.util = None
 
+        # PrintLog object
+        self.plog = PrintLog(self.space.keys)
+
         # Output dictionary
         self.res = {}
         # Output dictionary
         self.res['max'] = {'max_val': None,
                            'max_params': None}
         self.res['all'] = {'values': [], 'params': []}
-
-        self.plog = PrintLog(self.space.keys)
 
         # Verbose
         self.verbose = verbose

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from __future__ import division
 
 import numpy as np
+import warnings
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import Matern
 from .helpers import (UtilityFunction, PrintLog, unique_rows, acq_max,
@@ -317,3 +318,35 @@ class BayesianOptimization(object):
         points = np.hstack((self.space.X, np.expand_dims(self.space.Y, axis=1)))
         header = ', '.join(self.space.keys + ['target'])
         np.savetxt(file_name, points, header=header, delimiter=',')
+
+    # --- API compatibility ---
+
+    @property
+    def X(self):
+        warnings.warn("use self.space.X instead", DeprecationWarning)
+        return self.space.X
+
+    @property
+    def Y(self):
+        warnings.warn("use self.space.Y instead", DeprecationWarning)
+        return self.space.Y
+
+    @property
+    def keys(self):
+        warnings.warn("use self.space.keys instead", DeprecationWarning)
+        return self.space.keys
+
+    @property
+    def f(self):
+        warnings.warn("use self.space.target_func instead", DeprecationWarning)
+        return self.space.target_func
+
+    @property
+    def bounds(self):
+        warnings.warn("use self.space.dim instead", DeprecationWarning)
+        return self.space.bounds
+
+    @property
+    def dim(self):
+        warnings.warn("use self.space.dim instead", DeprecationWarning)
+        return self.space.dim

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -23,7 +23,7 @@ class TargetSpace(object):
         self.bounds = np.array(list(pbounds.values()), dtype=np.float)
         self.dim = len(pbounds)
 
-        # Place to constant-time append new values
+        # Place append new values in constant-time
         self.new_Xs = []
         self.new_Ys = []
 

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -126,6 +126,33 @@ class BayesianOptimization(object):
         # Updates the flag
         self.initialized = True
 
+    def eval_points(self, points):
+        """
+        Evaulates specific points and adds them to the set of known
+        observations self.X and self.Y
+        """
+        if self.X is None and self.Y is None:
+            self.X = np.empty((0, self.bounds.shape[0]))
+            self.Y = np.empty(0)
+
+        new_Xs = []
+        new_Ys = []
+
+        for x in points:
+            x = np.asarray(x).reshape((1, -1))
+            y = self.f(**dict(zip(self.keys, x)))
+
+            new_Xs.append(x)
+            new_Ys.append(y)
+
+            if self.verbose:
+                self.plog.print_step(x, self.Y[-1])
+
+        # Append the evaluated points
+        self.X = np.vstack([self.X] + new_Xs)
+        self.Y = np.hstack([self.Y] + new_Ys)
+
+
     def explore(self, points_dict):
         """Method to explore user defined points
 

--- a/bayes_opt/helpers.py
+++ b/bayes_opt/helpers.py
@@ -117,6 +117,8 @@ def unique_rows(a):
 
     :return: mask of unique rows
     """
+    if a.size == 0:
+        return np.empty((0,))
 
     # Sort array and kep track of where things should go back to
     order = np.lexsort(a.T)
@@ -128,6 +130,21 @@ def unique_rows(a):
     ui[1:] = (diff != 0).any(axis=1)
 
     return ui[reorder]
+
+
+def ensure_rng(random_state=None):
+    """
+    Creates a random number generator based on an optional seed.  This can be
+    an integer or another random state for a seeded rng, or None for an
+    unseeded rng.
+    """
+    if random_state is None:
+        random_state = np.random.RandomState()
+    elif isinstance(random_state, int):
+        random_state = np.random.RandomState(random_state)
+    else:
+        assert isinstance(random_state, np.random.RandomState)
+    return random_state
 
 
 class BColours(object):

--- a/bayes_opt/target_space.py
+++ b/bayes_opt/target_space.py
@@ -1,0 +1,300 @@
+from __future__ import print_function, division
+import numpy as np
+from .helpers import ensure_rng, unique_rows
+
+
+def _hashable(x):
+    """ ensure that an point is hashable by a python dict """
+    return tuple(map(float, x))
+
+
+class TargetSpace(object):
+    """
+    Holds the param-space coordinates (X) and target values (Y)
+    Allows for constant-time appends while ensuring no duplicates are added
+
+    Example
+    -------
+    >>> def target_func(p1, p2):
+    >>>     return p1 + p2
+    >>> pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+    >>> space = TargetSpace(target_func, pbounds, random_state=0)
+    >>> x = space.random_points(1)[0]
+    >>> y = space.observe_point(x)
+    >>> assert self.max_point()['max_val'] == y
+    """
+    def __init__(self, target_func, pbounds, random_state=None):
+        """
+        Parameters
+        ----------
+        target_func : function
+            Function to be maximized.
+
+        pbounds : dict
+            Dictionary with parameters names as keys and a tuple with minimum
+            and maximum values.
+
+        random_state : int, RandomState, or None
+            optionally specify a seed for a random number generator
+        """
+
+        self.random_state = ensure_rng(random_state)
+
+        # Some function to be optimized
+        self.target_func = target_func
+
+        # Get the name of the parameters
+        self.keys = list(pbounds.keys())
+        # Create an array with parameters bounds
+        self.bounds = np.array(list(pbounds.values()), dtype=np.float)
+        # Find number of parameters
+        self.dim = len(self.keys)
+
+        # preallocated memory for X and Y points
+        self._Xarr = None
+        self._Yarr = None
+
+        # Number of observations
+        self._length = 0
+
+        # Views of the preallocated arrays showing only populated data
+        self._Xview = None
+        self._Yview = None
+
+        self._cache = {}  # keep track of unique points we have seen so far
+
+    @property
+    def X(self):
+        return self._Xview
+
+    @property
+    def Y(self):
+        return self._Yview
+
+    def __contains__(self, x):
+        return _hashable(x) in self._cache
+
+    def __len__(self):
+        return self._length
+
+    def _dict_to_points(self, points_dict):
+        """
+        Example:
+        -------
+        >>> pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+        >>> space = TargetSpace(lambda p1, p2: p1 + p2, pbounds)
+        >>> points_dict = {'p1': [0, .5, 1], 'p2': [0, 1, 2]}
+        >>> space._dict_to_points(points_dict)
+        [[0, 0], [1, 0.5], [2, 1]]
+        """
+        # Consistency check
+        param_tup_lens = []
+
+        for key in self.keys:
+            param_tup_lens.append(len(list(points_dict[key])))
+
+        if all([e == param_tup_lens[0] for e in param_tup_lens]):
+            pass
+        else:
+            raise ValueError('The same number of initialization points '
+                             'must be entered for every parameter.')
+
+        # Turn into list of lists
+        all_points = []
+        for key in self.keys:
+            all_points.append(points_dict[key])
+
+        # Take transpose of list
+        points = list(map(list, zip(*all_points)))
+        return points
+
+    def observe_point(self, x):
+        """
+        Evaulates a single point x, to obtain the value y and then records them
+        as observations.
+
+        Notes
+        -----
+        If x has been previously seen returns a cached value of y.
+
+        Parameters
+        ----------
+        x : ndarray
+            a single point, with len(x) == self.dim
+
+        Returns
+        -------
+        y : float
+            target function value.
+        """
+        x = np.asarray(x).ravel()
+        assert x.size == self.dim, 'x must have the same dimensions'
+
+        if x in self:
+            # Lookup previously seen point
+            y = self._cache[_hashable(x)]
+        else:
+            # measure the target function
+            params = dict(zip(self.keys, x))
+            y = self.target_func(**params)
+            self.add_observation(x, y)
+        return y
+
+    def add_observation(self, x, y):
+        """
+        Append a point and its target value to the known data.
+
+        Parameters
+        ----------
+        x : ndarray
+            a single point, with len(x) == self.dim
+
+        y : float
+            target function value
+
+        Raises
+        ------
+        KeyError:
+            if the point is not unique
+
+        Notes
+        -----
+        runs in ammortized constant time
+
+        Example
+        -------
+        >>> pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+        >>> space = TargetSpace(lambda p1, p2: p1 + p2, pbounds)
+        >>> len(space)
+        0
+        >>> x = np.array([0, 0])
+        >>> y = 1
+        >>> space.add_observation(x, y)
+        >>> len(space)
+        1
+        """
+        if x in self:
+            raise KeyError('Data point {} is not unique'.format(x))
+
+        if self._length >= self._n_alloc_rows:
+            self._allocate((self._length + 1) * 2)
+
+        x = np.asarray(x).ravel()
+
+        # Insert data into unique dictionary
+        self._cache[_hashable(x)] = y
+
+        # Insert data into preallocated arrays
+        self._Xarr[self._length] = x
+        self._Yarr[self._length] = y
+        # Expand views to encompass the new data point
+        self._length += 1
+
+        # Create views of the data
+        self._Xview = self._Xarr[:self._length]
+        self._Yview = self._Yarr[:self._length]
+
+    def _allocate(self, num):
+        """
+        Allocate enough memory to store `num` points
+        """
+        if num <= self._n_alloc_rows:
+            raise ValueError('num must be larger than current array length')
+
+        self._assert_internal_invariants()
+
+        # Allocate new memory
+        _Xnew = np.empty((num, self.bounds.shape[0]))
+        _Ynew = np.empty(num)
+
+        # Copy the old data into the new
+        if self._Xarr is not None:
+            _Xnew[:self._length] = self._Xarr[:self._length]
+            _Ynew[:self._length] = self._Yarr[:self._length]
+        self._Xarr = _Xnew
+        self._Yarr = _Ynew
+
+        # Create views of the data
+        self._Xview = self._Xarr[:self._length]
+        self._Yview = self._Yarr[:self._length]
+
+    @property
+    def _n_alloc_rows(self):
+        """ Number of allocated rows """
+        return 0 if self._Xarr is None else self._Xarr.shape[0]
+
+    def random_points(self, num):
+        """
+        Creates random points within the bounds of the space
+
+        Parameters
+        ----------
+        num : int
+            Number of random points to create
+
+        Returns
+        ----------
+        data: ndarray
+            [num x dim] array points with dimensions corresponding to `self.keys`
+
+        Example
+        -------
+        >>> target_func = lambda p1, p2: p1 + p2
+        >>> pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+        >>> space = TargetSpace(target_func, pbounds, random_state=0)
+        >>> space.random_points(3)
+        array([[ 55.33253689,   0.54488318],
+               [ 71.80374727,   0.4236548 ],
+               [ 60.67357423,   0.64589411]])
+        """
+        # TODO: support integer, category, and basic scipy.optimize constraints
+        data = np.empty((num, self.dim))
+        for col, (lower, upper) in enumerate(self.bounds):
+            data.T[col] = self.random_state.uniform(lower, upper, size=num)
+        return data
+
+    def max_point(self):
+        """
+        Return the current parameters that best maximize target function with
+        that maximum value.
+        """
+        return {'max_val': self.Y.max(),
+                'max_params': dict(zip(self.keys,
+                                       self.X[self.Y.argmax()]))}
+
+    def set_bounds(self, new_bounds):
+        """
+        A method that allows changing the lower and upper searching bounds
+
+        Parameters
+        ----------
+        new_bounds : dict
+            A dictionary with the parameter name and its new bounds
+        """
+        # Loop through the all bounds and reset the min-max bound matrix
+        for row, key in enumerate(self.keys):
+            if key in new_bounds:
+                self.bounds[row] = new_bounds[key]
+
+    def _assert_internal_invariants(self, fast=True):
+        """
+        Run internal consistency checks to ensure that data structure
+        assumptions have not been violated.
+        """
+        if self._Xarr is None:
+            assert self._Yarr is None
+            assert self._Xview is None
+            assert self._Yview is None
+        else:
+            assert self._Yarr is not None
+            assert self._Xview is not None
+            assert self._Yview is not None
+            assert len(self._Xview) == self._length
+            assert len(self._Yview) == self._length
+            assert len(self._Xarr) == len(self._Yarr)
+
+            if not fast:
+                # run slower checks
+                assert np.all(unique_rows(self.X))
+                # assert np.may_share_memory(self._Xview, self._Xarr)
+                # assert np.may_share_memory(self._Yview, self._Yarr)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+;addopts = -p no:doctest --xdoctest --xdoctest-style=google
+norecursedirs = .git ignore build __pycache__
+
+filterwarnings= default

--- a/tests/test_bayesian_optimization.py
+++ b/tests/test_bayesian_optimization.py
@@ -1,0 +1,114 @@
+from bayes_opt import BayesianOptimization
+from bayes_opt.helpers import ensure_rng
+import numpy as np
+
+
+def test_bayes_opt_demo():
+    """
+    pytest tests/test_bayesian_optimization.py::test_bayes_opt_demo
+
+    See Also
+    --------
+    https://github.com/fmfn/BayesianOptimization/blob/master/examples/exploitation%20vs%20exploration.ipynb
+    """
+    random_state = ensure_rng(0)
+    xs = np.linspace(-2, 10, 1000)
+    f = np.exp(-(xs - 2)**2) + np.exp(-(xs - 6)**2 / 10) + 1 / (xs**2 + 1)
+    bo = BayesianOptimization(f=lambda x: f[int(x)],
+                              pbounds={'x': (0, len(f) - 1)},
+                              random_state=random_state,
+                              verbose=0)
+    gp_params = {'alpha': 1e-5, 'n_restarts_optimizer': 2}
+    bo.maximize(init_points=10, n_iter=10, acq='ucb', kappa=5, **gp_params)
+    res = bo.space.max_point()
+    max_params = res['max_params']
+    max_val = res['max_val']
+
+    assert max_val > 1.2, 'function range is ~.2 - ~1.4, should be above 1.'
+    assert max_val / f.max() > .9, 'should be better than 90% of max val'
+
+    assert max_params['x'] > 300, 'should be in a peak area (around 300)'
+    assert max_params['x'] < 400, 'should be in a peak area (around 300)'
+
+
+def test_only_random():
+    random_state = ensure_rng(0)
+    xs = np.linspace(-2, 10, 1000)
+    f = np.exp(-(xs - 2)**2) + np.exp(-(xs - 6)**2 / 10) + 1 / (xs**2 + 1)
+    bo = BayesianOptimization(f=lambda x: f[int(x)],
+                              pbounds={'x': (0, len(f) - 1)},
+                              random_state=random_state,
+                              verbose=0)
+    bo.init(20)
+    res = bo.space.max_point()
+    max_params = res['max_params']
+    max_val = res['max_val']
+
+    assert max_val > 1.0, 'function range is ~.2 - ~1.4, should be above 1.'
+    assert max_val / f.max() > .8, 'should be better than 80% of max val'
+
+    assert max_params['x'] > 200, 'should be in a peak area (around 300)'
+    assert max_params['x'] < 500, 'should be in a peak area (around 300)'
+
+
+def test_explore_lazy():
+    random_state = ensure_rng(0)
+    xs = np.linspace(-2, 10, 1000)
+    f = np.exp(-(xs - 2)**2) + np.exp(-(xs - 6)**2 / 10) + 1 / (xs**2 + 1)
+    bo = BayesianOptimization(f=lambda x: f[int(x)],
+                              pbounds={'x': (0, len(f) - 1)},
+                              random_state=random_state,
+                              verbose=0)
+    bo.explore({'x': [f.argmin()]}, eager=False)
+    assert len(bo.space) == 0
+    assert len(bo.init_points) == 1
+
+    # Note we currently expect lazy explore to override points
+    # This may not be the case in the future.
+    bo.explore({'x': [f.argmax()]}, eager=False)
+    assert len(bo.space) == 0
+    assert len(bo.init_points) == 1
+
+    bo.maximize(init_points=0, n_iter=0, acq='ucb', kappa=5)
+
+    res = bo.space.max_point()
+    max_params = res['max_params']
+    max_val = res['max_val']
+
+    assert max_params['x'] == f.argmax()
+    assert max_val == f.max()
+
+
+def test_explore_eager():
+    random_state = ensure_rng(0)
+    xs = np.linspace(-2, 10, 1000)
+    f = np.exp(-(xs - 2)**2) + np.exp(-(xs - 6)**2 / 10) + 1 / (xs**2 + 1)
+    bo = BayesianOptimization(f=lambda x: f[int(x)],
+                              pbounds={'x': (0, len(f) - 1)},
+                              random_state=random_state,
+                              verbose=0)
+    bo.explore({'x': [f.argmin()]}, eager=True)
+    assert len(bo.space) == 1
+    assert len(bo.init_points) == 0
+
+    # Note we currently expect lazy explore to override points
+    # This may not be the case in the future.
+    bo.explore({'x': [f.argmax()]}, eager=True)
+    assert len(bo.space) == 2
+    assert len(bo.init_points) == 0
+
+    res = bo.space.max_point()
+    max_params = res['max_params']
+    max_val = res['max_val']
+
+    assert max_params['x'] == f.argmax()
+    assert max_val == f.max()
+
+
+if __name__ == '__main__':
+    r"""
+    CommandLine:
+        python tests/test_bayesian_optimization.py
+    """
+    import pytest
+    pytest.main([__file__])

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -4,11 +4,7 @@ import unittest
 import numpy as np
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import Matern
-# import sys
-# sys.path.append("./")
-# sys.path.append("../bayes_opt/")
-# from bayes_opt.helpers import UtilityFunction, acq_max
-from bayes_opt.helpers import UtilityFunction, acq_max
+from bayes_opt.helpers import UtilityFunction, acq_max, ensure_rng
 
 
 def get_globals():
@@ -61,11 +57,13 @@ class TestMaximizationOfAcquisitionFunction(unittest.TestCase):
         self.util = UtilityFunction(kind=kind, kappa=kappa, xi=xi)
         self.episilon = 1e-2
         self.y_max = 2.0
+        self.random_state = ensure_rng(0)
 
     def test_acq_max_function_with_ucb_algo(self):
         self.setUp(kind='ucb', kappa=1.0, xi=1.0)
         max_arg = acq_max(
-            self.util.utility, GP, self.y_max, bounds=np.array([[0, 1], [0, 1]])
+            self.util.utility, GP, self.y_max, bounds=np.array([[0, 1], [0, 1]]),
+            random_state=self.random_state
         )
         _, brute_max_arg = brute_force_maximum(MESH, GP)
 
@@ -74,7 +72,8 @@ class TestMaximizationOfAcquisitionFunction(unittest.TestCase):
     def test_ei_max_function_with_ucb_algo(self):
         self.setUp(kind='ei', kappa=1.0, xi=1e-6)
         max_arg = acq_max(
-            self.util.utility, GP, self.y_max, bounds=np.array([[0, 1], [0, 1]])
+            self.util.utility, GP, self.y_max, bounds=np.array([[0, 1], [0, 1]]),
+            random_state=self.random_state
         )
         _, brute_max_arg = brute_force_maximum(MESH, GP, kind='ei')
 
@@ -82,4 +81,10 @@ class TestMaximizationOfAcquisitionFunction(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    r"""
+    CommandLine:
+        python tests/test_target_space.py
+    """
+    # unittest.main()
+    import pytest
+    pytest.main([__file__])

--- a/tests/test_target_space.py
+++ b/tests/test_target_space.py
@@ -1,0 +1,109 @@
+from bayes_opt.target_space import TargetSpace
+import pytest
+import numpy as np
+
+
+def target_func(**kw):
+    # arbitrary target func
+    return sum(kw.values())
+
+
+def test_empty():
+    pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+    space = TargetSpace(target_func, pbounds)
+    space._assert_internal_invariants(fast=False)
+    assert space._n_alloc_rows == len(space)
+
+
+def test_one_point():
+    pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+    space = TargetSpace(target_func, pbounds)
+    x = space.random_points(1)[0]
+    space.observe_point(x)
+    space._assert_internal_invariants(fast=False)
+    assert space._n_alloc_rows > len(space)
+
+
+def test_two_points():
+    """
+    pytest tests/test_target_space.py::test_two_points
+    """
+    pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+    space = TargetSpace(target_func, pbounds)
+    for x in space.random_points(2):
+        space.observe_point(x)
+        space._assert_internal_invariants(fast=False)
+    space._assert_internal_invariants(fast=False)
+    assert space._n_alloc_rows == len(space)
+
+
+def test_nonunique_add():
+    # Adding non-unique values throws a KeyError
+    pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+    space = TargetSpace(target_func, pbounds)
+    x = [0, 0]
+    y = 0
+    space.add_observation(x, y)
+
+    with pytest.raises(KeyError):
+        space.add_observation(x, y)
+
+    space._assert_internal_invariants(fast=False)
+
+
+def test_nonunique_observe():
+    # Simply re-observing a non-unique values returns the cached result
+    pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+    space = TargetSpace(target_func, pbounds)
+    x = [0, 0]
+    y = 0
+    space.add_observation(x, y)
+
+    with pytest.raises(KeyError):
+        space.add_observation(x, y)
+
+    space._assert_internal_invariants(fast=False)
+
+
+def test_contains():
+    # Simply re-observing a non-unique values returns the cached result
+    pbounds = {'p1': (0, 1), 'p2': (1, 100)}
+    space = TargetSpace(target_func, pbounds)
+    # add 1000 random points
+    for x in space.random_points(1000):
+        space.observe_point(x)
+    # now all points should be unique, so test contains
+    space2 = TargetSpace(target_func, pbounds)
+    for x in space.X:
+        assert x not in space2
+        y = space2.observe_point(x)
+        assert x in space2
+        assert y == space2.observe_point(x)
+    space2._assert_internal_invariants(fast=False)
+
+
+@pytest.mark.parametrize("m", [0, 1, 2, 5, 20, 100])
+@pytest.mark.parametrize("n", [0, 1, 2, 3, 10])
+def test_m_random_nd_points(m, n):
+    pbounds = {'p{}'.format(i): (0, i) for i in range(n)}
+    space = TargetSpace(target_func, pbounds, random_state=0)
+
+    X = space.random_points(m)
+    assert X.shape[0] == m
+    assert X.shape[1] == n
+
+    for i in range(n):
+        lower, upper = pbounds[space.keys[i]]
+        assert np.all(X.T[i] >= lower)
+        assert np.all(X.T[i] <= upper)
+
+
+@pytest.mark.parametrize("m", [0, 1, 2, 5, 20, 100])
+@pytest.mark.parametrize("n", [0, 1, 2, 3, 10])
+def test_observe_m_nd_points(m, n):
+    pbounds = {'p{}'.format(i): (0, i) for i in range(n)}
+    space = TargetSpace(target_func, pbounds)
+    for x in space.random_points(m):
+        space.observe_point(x)
+        space._assert_internal_invariants(fast=False)
+    space._assert_internal_invariants(fast=False)

--- a/tests/test_target_space.py
+++ b/tests/test_target_space.py
@@ -107,3 +107,12 @@ def test_observe_m_nd_points(m, n):
         space.observe_point(x)
         space._assert_internal_invariants(fast=False)
     space._assert_internal_invariants(fast=False)
+
+
+if __name__ == '__main__':
+    r"""
+    CommandLine:
+        python tests/test_target_space.py
+    """
+    import pytest
+    pytest.main([__file__])

--- a/tests/tests_helper_functions.py
+++ b/tests/tests_helper_functions.py
@@ -4,11 +4,11 @@ import unittest
 import numpy as np
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import Matern
-import sys
-sys.path.append("./")
-sys.path.append("../bayes_opt/")
+# import sys
+# sys.path.append("./")
+# sys.path.append("../bayes_opt/")
 # from bayes_opt.helpers import UtilityFunction, acq_max
-from helpers import UtilityFunction, acq_max
+from bayes_opt.helpers import UtilityFunction, acq_max
 
 
 def get_globals():


### PR DESCRIPTION
This PR address an issue I've been experiencing in interactive use. I want to run the maximization function and then try custom values based in its result. However, the only way to do that is to "initialize", and doing that blows away all previous values of `self.X` and `self.Y`. 

To this end I made a function `explore_eager` (name pending), which works like `explore`, but immediately evaluates those values and adds them to your current explored data. It does this in such a way that if self.maximize is called again it uses the new custom points when it fits its GMM. 

Now, to make this change I had to do some non-trivial code refactoring. I saw a few issues in the code base that I felt I should address while I was in there. The main problem was the use of np.vstack and np.append after evaluating every single point. These numpy methods are O(n) as opposed to the O(1) python list.append function. With a large sample, these will eventually start causing problems. 

To fix this I abstracted the point storage into a class called `TargetSpace` to manage the bounds, X array, and Y array. Instead of using python lists I found that using custom np.empty over-allocation with numpy views to be an effective solution. This also prevents the need for casting a list of lists to an array when a scipy function is called (which would also be O(n)). 

I think the TargetSpace api is pretty clean and it makes the code in bayesian_optimization.py a lot simpler. The main function are:
 * observe_point(x) : evaluate y = f(x), record and return y. Memoize the result. 
 * add_observation(x, y): add a known x and y point. Raises a KeyError if x was already added. 
 * random_points(num): generates `num` random points within the bounds. 
 * max_point() - returns the best x/y pair so far
 * set_bounds(new_bounds) - updates the bounds (for consistency with exiting api)
 * `__len__` - num unique points added so far
 * `__contains__` - returns True if we have seen the point thusfar
 * X - property which behaves like the old `self.X`
 * Y - property which behaves like the old `self.Y`

Because the class manages only unique points, we can avoid removing duplicates every time a GP is fit. This should also offer some amount of speedup. 

Because this is a fairly large change I also added comprehensive unit tests (targeted towards pytest).

Having this structure should make it possible to further simplify the   `bayesian_optimization.py` codebase and api, but I wanted to make those changes fairly minimal at least in this first pass. (For instance it should be possible to seemlessly accept a dict of lists / list of dicts / ndarray / list of lists / pandas dataframe as an input point(s).)

