### PR TITLE
Fix csv issue in the points_to_csv method

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -319,8 +319,8 @@ class BayesianOptimization(object):
         """
 
         points = np.hstack((self.space.X, np.expand_dims(self.space.Y, axis=1)))
-        header = ', '.join(self.space.keys + ['target'])
-        np.savetxt(file_name, points, header=header, delimiter=',')
+        header = ','.join(self.space.keys + ['target'])
+        np.savetxt(file_name, points, header=header, delimiter=',', comments='')
 
     # --- API compatibility ---
 


### PR DESCRIPTION
The current `header` argument in the `np.savetxt` call inside of the `points_to_csv` method is not compatible with the format expected from the `initialize_df` method.

A call to `initialize_df` when the argument is a pandas DataFrame constructed by reading the output of `points_to_csv` with `pandas.read_csv` will fail because of a wrong format of the header.

In particular, the issues here are the following:

1. the header of the csv file is generated with a leading pound character ('#') that comes from the default `comments='#'` of `np.savetxt`

2. the column names are prefixed with an unnecessary space in by `', '.join(self.space.keys + ['target'])` inside of `points_to_csv`.

This pull request fixes the above two issues. I tested these changes on a notebook that I am happy to share upon request.

At the cost of making `pandas` an additional dependency, it may be easier to use `pandas` in methods such as `points_to_csv` and `initialize_df`.