### PR TITLE
Feature/parameter dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ scratch/
 .DS_Store
 bo_eg*.png
 gif/
+__pycache__
+.pytest_cache
 
 # Unit test / coverage reports
 htmlcov/

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -25,7 +25,7 @@ class BayesianOptimization(object):
             and SLSQP optimizers. Each dictionary has the fields:
             
             - type : str
-              Constraint type: ‘eq’ for equality, ‘ineq’ for inequality.
+              Constraint type: 'eq' for equality, 'ineq' for inequality.
             - fun : callable
               The function defining the constraint.
             - jac : callable, optional

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -11,7 +11,7 @@ from .target_space import TargetSpace
 
 class BayesianOptimization(object):
 
-    def __init__(self, f, pbounds, random_state=None, verbose=1):
+    def __init__(self, f, pbounds, constraints=None, random_state=None, verbose=1):
         """
         :param f:
             Function to be maximized.
@@ -19,6 +19,23 @@ class BayesianOptimization(object):
         :param pbounds:
             Dictionary with parameters names as keys and a tuple with minimum
             and maximum values.
+            
+        :param constraints:
+            List of dictionaries defining constraints for parameters for COBYLA
+            and SLSQP optimizers. Each dictionary has the fields:
+            
+            - type : str
+              Constraint type: ‘eq’ for equality, ‘ineq’ for inequality.
+            - fun : callable
+              The function defining the constraint.
+            - jac : callable, optional
+              The Jacobian of fun (only for SLSQP).
+            - args : sequence, optional
+              Extra arguments to be passed to the function and Jacobian.
+              
+            Equality constraint means that the constraint function result is to be
+            zero whereas inequality means that it is to be non-negative. Note that
+            COBYLA only supports inequality constraints.
 
         :param verbose:
             Whether or not to print progress.
@@ -26,6 +43,9 @@ class BayesianOptimization(object):
         """
         # Store the original dictionary
         self.pbounds = pbounds
+        
+        # Store the constraints
+        self.constraints = constraints
 
         self.random_state = ensure_rng(random_state)
 
@@ -255,6 +275,7 @@ class BayesianOptimization(object):
                         gp=self.gp,
                         y_max=y_max,
                         bounds=self.space.bounds,
+                        constraints=self.constraints,
                         random_state=self.random_state,
                         **self._acqkw)
 
@@ -297,6 +318,7 @@ class BayesianOptimization(object):
                             gp=self.gp,
                             y_max=y_max,
                             bounds=self.space.bounds,
+                            constraints=self.constraints,
                             random_state=self.random_state,
                             **self._acqkw)
 

--- a/bayes_opt/helpers.py
+++ b/bayes_opt/helpers.py
@@ -64,7 +64,7 @@ def acq_max(ac, gp, y_max, bounds, random_state, n_warmup=100000, n_iter=250,
             # Using constraints. Note the optimizer can be 'SLSQP', 'COBYLA', or 'trust-constr'.
             # The first two use a dictionary defining constraints, the last one uses a list of
             # constraint objects from scipy. Choosing 'SLSQP' for now.
-            res = minimize(lambda x: -ac(x.reshape(1, -1), gp=gp, ymax=ymax),
+            res = minimize(lambda x: -ac(x.reshape(1, -1), gp=gp, y_max=y_max),
                            x_try.reshape(1, -1),
                            bounds=bounds,
                            method='SLSQP',
@@ -75,6 +75,8 @@ def acq_max(ac, gp, y_max, bounds, random_state, n_warmup=100000, n_iter=250,
             continue
            
         # Store it if better than previous minimum(maximum).
+        if not isinstance(res.fun, list):
+            res.fun = [res.fun]
         if max_acq is None or -res.fun[0] >= max_acq:
             x_max = res.x
             max_acq = -res.fun[0]

--- a/examples/sklearn_example.py
+++ b/examples/sklearn_example.py
@@ -49,11 +49,23 @@ if __name__ == "__main__":
         'max_features': (0.1, 0.999)}
     )
 
+    # Add a constraint that we have five times as many estimators as features.
+    rfcBO_constr = BayesianOptimization(
+        rfccv,
+        {'n_estimators': (10, 250),
+        'min_samples_split': (2, 25),
+        'max_features': (0.1, 0.999)},
+        constraints=[{'type': 'ineq',
+                      'fun': lambda x: int(x[0]) - 5*int(x[2] * 45)}]
+    )
+
     svcBO.maximize(n_iter=10, **gp_params)
     print('-' * 53)
     rfcBO.maximize(n_iter=10, **gp_params)
-
+    print('-' * 53)
+    rfcBO_constr.maximize(n_iter=10, **gp_params)
     print('-' * 53)
     print('Final Results')
     print('SVC: %f' % svcBO.res['max']['max_val'])
     print('RFC: %f' % rfcBO.res['max']['max_val'])
+    print(f"RFC with constraints: {rfcBO_constr.res['max']['max_val']}")


### PR DESCRIPTION
Updated maximization routine to accept constraints using the SLSQP optimizer. Added tests. This resolves issue #94.

It looks like the system will still guess outside of the constraints sometimes, but the updated `sklearn_example`, at least in my testing, showed that it mostly respects the constraints. The example shown for the `maximize` method still finds the global max, despite the constraint trying to restrict it to values above the 5000th index.