### PR TITLE
All observed points added to result dict

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -100,10 +100,16 @@ class BayesianOptimization(object):
         # Updates the flag
         self.initialized = True
 
-    def _observe_point(self, x):
+    def _observe_point(self, x, pwarning=False):
         y = self.space.observe_point(x)
+
+        # Update the best params seen so far
+        self.res['max'] = self.space.max_point()
+        self.res['all']['values'].append(y)
+        self.res['all']['params'].append(dict(zip(self.space.keys, x)))
+
         if self.verbose:
-            self.plog.print_step(x, y)
+            self.plog.print_step(x, y, pwarning)
         return y
 
     def explore(self, points_dict, eager=False):
@@ -276,17 +282,10 @@ class BayesianOptimization(object):
                 pwarning = True
 
             # Append most recently generated values to X and Y arrays
-            y = self.space.observe_point(x_max)
-            if self.verbose:
-                self.plog.print_step(x_max, y, pwarning)
+            y = self._observe_point(x_max, pwarning=pwarning)
 
             # Updating the GP.
             self.gp.fit(self.space.X, self.space.Y)
-
-            # Update the best params seen so far
-            self.res['max'] = self.space.max_point()
-            self.res['all']['values'].append(y)
-            self.res['all']['params'].append(dict(zip(self.space.keys, x_max)))
 
             # Update maximum value to search for next probe point.
             if self.space.Y[-1] > y_max:


### PR DESCRIPTION
Hello,

I feel all observed points should be added to the results dict, not only the ones observed after the Bayesian fit. The random points in the initialization and the points explored by the user are equally valid, right? It would be sad if the maximum is one of them and it's therefore missed :)

I thought the best way to ensure all observed points are added to the results dict is to just do that in `BayesianOptimization._observe_point()`.

Cheers,
Jonas