### PR TITLE
Default and ready to use observers

### DIFF
--- a/bayes_opt/__init__.py
+++ b/bayes_opt/__init__.py
@@ -1,5 +1,5 @@
 from .bayesian_optimization import BayesianOptimization, Events
-from .helpers import UtilityFunction
-from .observer import Observer
+from .util import UtilityFunction
+from .observer import ScreenLogger
 
-__all__ = ["BayesianOptimization", "UtilityFunction", "Events", "Observer"]
+__all__ = ["BayesianOptimization", "UtilityFunction", "Events", "ScreenLogger"]

--- a/bayes_opt/event.py
+++ b/bayes_opt/event.py
@@ -1,0 +1,19 @@
+class Events:
+    OPTMIZATION_START = 'optmization:start'
+    OPTMIZATION_STEP = 'optmization:step'
+    OPTMIZATION_END = 'optmization:end'
+
+    PROBE_FROM_SUGGESTION = "probe:suggestion"
+    PROBE_FROM_QUEUE = "probe:queue"
+
+    ELEMENT_ADDED_TO_QUEUE = ""
+    QUEUE_IS_EMPTY = ""
+
+
+DEFAULT_EVENTS = [
+    Events.OPTMIZATION_START,
+    Events.OPTMIZATION_STEP,
+    Events.OPTMIZATION_END,
+    Events.ELEMENT_ADDED_TO_QUEUE,
+    Events.QUEUE_IS_EMPTY,
+]

--- a/bayes_opt/target_space.py
+++ b/bayes_opt/target_space.py
@@ -1,6 +1,5 @@
-from __future__ import print_function, division
 import numpy as np
-from .helpers import ensure_rng, unique_rows
+from .util import ensure_rng, unique_rows
 
 
 def _hashable(x):
@@ -226,7 +225,7 @@ class TargetSpace(object):
         params = [dict(zip(self.keys, p)) for p in self.x]
 
         return [
-            {"target": target, "param": param}
+            {"target": target, "params": param}
             for target, param in zip(self.target, params)
         ]
 

--- a/bayes_opt/util.py
+++ b/bayes_opt/util.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 from __future__ import division
 import warnings
 import numpy as np
-from datetime import datetime
 from scipy.stats import norm
 from scipy.optimize import minimize
 
@@ -169,100 +168,70 @@ def ensure_rng(random_state=None):
     return random_state
 
 
-class BColours(object):
+class Colours:
+    """Print in nice colours."""
+
     BLUE = '\033[94m'
-    CYAN = '\033[36m'
-    GREEN = '\033[32m'
-    MAGENTA = '\033[35m'
-    RED = '\033[31m'
-    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    CYAN = '\033[96m'
+    DARKCYAN = '\033[36m'
+    END = '\033[0m'
+    GREEN = '\033[92m'
+    PURPLE = '\033[95m'
+    RED = '\033[91m'
+    UNDERLINE = '\033[4m'
+    YELLOW = '\033[93m'
 
+    @classmethod
+    def _wrap_colour(cls, s, colour):
+        return colour + s + cls.END
 
-class PrintLog(object):
+    @classmethod
+    def black(cls, s):
+        """Wrap text in blue."""
+        return cls._wrap_colour(s, cls.END)
 
-    def __init__(self, params):
+    @classmethod
+    def blue(cls, s):
+        """Wrap text in blue."""
+        return cls._wrap_colour(s, cls.BLUE)
 
-        self.ymax = None
-        self.xmax = None
-        self.params = params
-        self.ite = 1
+    @classmethod
+    def bold(cls, s):
+        """Wrap text in bold."""
+        return cls._wrap_colour(s, cls.BOLD)
 
-        self.start_time = datetime.now()
-        self.last_round = datetime.now()
+    @classmethod
+    def cyan(cls, s):
+        """Wrap text in cyan."""
+        return cls._wrap_colour(s, cls.CYAN)
 
-        # sizes of parameters name and all
-        self.sizes = [max(len(ps), 7) for ps in params]
+    @classmethod
+    def darkcyan(cls, s):
+        """Wrap text in darkcyan."""
+        return cls._wrap_colour(s, cls.DARKCYAN)
 
-        # Sorted indexes to access parameters
-        self.sorti = sorted(range(len(self.params)),
-                            key=self.params.__getitem__)
+    @classmethod
+    def green(cls, s):
+        """Wrap text in green."""
+        return cls._wrap_colour(s, cls.GREEN)
 
-    def reset_timer(self):
-        self.start_time = datetime.now()
-        self.last_round = datetime.now()
+    @classmethod
+    def purple(cls, s):
+        """Wrap text in purple."""
+        return cls._wrap_colour(s, cls.PURPLE)
 
-    def print_header(self, initialization=True):
+    @classmethod
+    def red(cls, s):
+        """Wrap text in red."""
+        return cls._wrap_colour(s, cls.RED)
 
-        if initialization:
-            print("{}Initialization{}".format(BColours.RED,
-                                              BColours.ENDC))
-        else:
-            print("{}Bayesian Optimization{}".format(BColours.RED,
-                                                     BColours.ENDC))
+    @classmethod
+    def underline(cls, s):
+        """Wrap text in underline."""
+        return cls._wrap_colour(s, cls.UNDERLINE)
 
-        print(BColours.BLUE + "-" * (29 + sum([s + 5 for s in self.sizes])) +
-            BColours.ENDC)
-
-        print("{0:>{1}}".format("Step", 5), end=" | ")
-        print("{0:>{1}}".format("Time", 6), end=" | ")
-        print("{0:>{1}}".format("Value", 10), end=" | ")
-
-        for index in self.sorti:
-            print("{0:>{1}}".format(self.params[index],
-                                    self.sizes[index] + 2),
-                  end=" | ")
-        print('')
-
-    def print_step(self, x, y, warning=False):
-
-        print("{:>5d}".format(self.ite), end=" | ")
-
-        m, s = divmod((datetime.now() - self.last_round).total_seconds(), 60)
-        print("{:>02d}m{:>02d}s".format(int(m), int(s)), end=" | ")
-
-        if self.ymax is None or self.ymax < y:
-            self.ymax = y
-            self.xmax = x
-            print("{0}{2: >10.5f}{1}".format(BColours.MAGENTA,
-                                             BColours.ENDC,
-                                             y),
-                  end=" | ")
-
-            for index in self.sorti:
-                print("{0}{2: >{3}.{4}f}{1}".format(
-                            BColours.GREEN, BColours.ENDC,
-                            x[index],
-                            self.sizes[index] + 2,
-                            min(self.sizes[index] - 3, 6 - 2)
-                        ),
-                      end=" | ")
-        else:
-            print("{: >10.5f}".format(y), end=" | ")
-            for index in self.sorti:
-                print("{0: >{1}.{2}f}".format(x[index],
-                                              self.sizes[index] + 2,
-                                              min(self.sizes[index] - 3, 6 - 2)),
-                      end=" | ")
-
-        if warning:
-            print("{}Warning: Test point chose at "
-                  "random due to repeated sample.{}".format(BColours.RED,
-                                                            BColours.ENDC))
-
-        print()
-
-        self.last_round = datetime.now()
-        self.ite += 1
-
-    def print_summary(self):
-        pass
+    @classmethod
+    def yellow(cls, s):
+        """Wrap text in yellow."""
+        return cls._wrap_colour(s, cls.YELLOW)

--- a/tests/test_bayesian_optimization.py
+++ b/tests/test_bayesian_optimization.py
@@ -1,5 +1,5 @@
 from bayes_opt import BayesianOptimization
-from bayes_opt.helpers import ensure_rng
+from bayes_opt.util import ensure_rng
 import numpy as np
 
 

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import Matern
-from bayes_opt.helpers import UtilityFunction, acq_max, ensure_rng
+from bayes_opt.util import UtilityFunction, acq_max, ensure_rng
 
 def get_globals():
     X = np.array([


### PR DESCRIPTION
This commit refactors heavily how loggin is done in the package. It
removes the old style of loggin and does everything now using observers.
By default the user has access to two useful observers, json and
printer, and if the users doesn't want to deal with that the verbose
parameter takes care of the basics.