### PR TITLE
add parameters type description in list of parameters bounds

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -65,7 +65,7 @@ class BayesianOptimization(Observable):
                            'max_params': None}
         self.res['all'] = {'values': [], 'params': []}
 
-        # non-public config for maximizing the aquisition function
+        # non-public config for maximizing the acquisition function
         # (used to speedup tests, but generally leave these as is)
         self._acqkw = {'n_warmup': 100000, 'n_iter': 250}
 
@@ -118,7 +118,7 @@ class BayesianOptimization(Observable):
         """Method to explore user defined points.
 
         :param points_dict:
-        :param eager: if True, these points are evaulated immediately
+        :param eager: if True, these points are evaluated immediately
         """
         if eager:
             self.plog.reset_timer()
@@ -263,6 +263,7 @@ class BayesianOptimization(Observable):
                         gp=self.gp,
                         y_max=y_max,
                         bounds=self.space.bounds,
+                        btypes=self.space.btypes,
                         random_state=self.random_state,
                         **self._acqkw)
 
@@ -305,6 +306,7 @@ class BayesianOptimization(Observable):
                             gp=self.gp,
                             y_max=y_max,
                             bounds=self.space.bounds,
+                            btypes=self.space.btypes,
                             random_state=self.random_state,
                             **self._acqkw)
 

--- a/bayes_opt/helpers.py
+++ b/bayes_opt/helpers.py
@@ -6,7 +6,7 @@ from scipy.stats import norm
 from scipy.optimize import minimize
 
 
-def acq_max(ac, gp, y_max, bounds, random_state, n_warmup=100000, n_iter=250):
+def acq_max(ac, gp, y_max, bounds, btypes, random_state, n_warmup=100000, n_iter=250):
     """
     A function to find the maximum of the acquisition function
 
@@ -28,6 +28,9 @@ def acq_max(ac, gp, y_max, bounds, random_state, n_warmup=100000, n_iter=250):
     :param bounds:
         The variables bounds to limit the search of the acq max.
 
+    :param btypes:
+        The types of the variables.
+
     :param random_state:
         instance of np.RandomState random number generator
 
@@ -43,30 +46,54 @@ def acq_max(ac, gp, y_max, bounds, random_state, n_warmup=100000, n_iter=250):
     """
 
     # Warm up with random points
-    x_tries = random_state.uniform(bounds[:, 0], bounds[:, 1],
-                                   size=(n_warmup, bounds.shape[0]))
+    x_tries = np.empty((n_warmup, bounds.shape[0]))
+    for col, name in enumerate(bounds):
+        # print(col, name)
+        lower, upper = name
+        if btypes[col] != int:
+            x_tries[:, col] = random_state.uniform(lower, upper, size=n_warmup)
+        if btypes[col] == int:
+            x_tries[:, col] = random_state.randint(int(lower), int(upper), size=n_warmup)
     ys = ac(x_tries, gp=gp, y_max=y_max)
     x_max = x_tries[ys.argmax()]
     max_acq = ys.max()
 
     # Explore the parameter space more throughly
-    x_seeds = random_state.uniform(bounds[:, 0], bounds[:, 1],
-                                   size=(n_iter, bounds.shape[0]))
+    x_seeds = np.empty((n_iter, bounds.shape[0]))
+    for col, name in enumerate(bounds):
+        lower, upper = name
+        if btypes[col] != int:
+            x_seeds[:, col] = random_state.uniform(lower, upper, size=n_iter)
+        if btypes[col] == int:
+            x_seeds[:, col] = random_state.randint(int(lower), int(upper), size=n_iter)
+    x_seeds = np.random.permutation(np.unique(x_seeds, axis=0))
     for x_try in x_seeds:
         # Find the minimum of minus the acquisition function
-        res = minimize(lambda x: -ac(x.reshape(1, -1), gp=gp, y_max=y_max),
+        ac_op = lambda x: -ac(x.reshape(1, -1), gp=gp, y_max=y_max)
+        res = minimize(ac_op,
                        x_try.reshape(1, -1),
                        bounds=bounds,
                        method="L-BFGS-B")
-
-        # See if success
-        if not res.success:
-            continue
-           
-        # Store it if better than previous minimum(maximum).
-        if max_acq is None or -res.fun[0] >= max_acq:
-            x_max = res.x
-            max_acq = -res.fun[0]
+        # If integer in list of bounds
+        # search minimum between surroundings integers of the detected extremal point
+        if int in btypes :
+            x_inf = res.x.copy()
+            x_sup = res.x.copy()
+            for i, (val, t) in enumerate(zip(res.x, btypes)):
+                x_inf[i] = t(val)
+                x_sup[i] = t(val + 1) if t == int else t(val)
+            # Store it if better than previous minimum(maximum).
+            x_ext = [x_inf, x_sup]
+            if max_acq is None or -res.fun[0] >= max_acq:
+                max_acq = -1*np.minimum(ac_op(x_inf), ac_op(x_sup))
+                x_argmax = np.argmin((ac_op(x_inf), ac_op(x_sup)))
+                x_max = x_ext[x_argmax]
+        # If only float in bounds
+        # store it if better than previous minimum(maximum).
+        else :
+            if max_acq is None or -res.fun[0] >= max_acq:
+                x_max = res.x
+                max_acq = -res.fun[0]
 
     # Clip output to make sure it lies within the bounds. Due to floating
     # point technicalities this is not always the case.


### PR DESCRIPTION
Parameters type are included into pbounds: `pbounds = {'p1': [int,(0, 1)], 'p2': [float,(1, 100)]}`
After the minimization and to avoid floating result for integer parameter, the parameter returned corresponds to the minimum between the lower and higher integer values of the floating returned value.
This solution assumes that the acquisition to be minimized is regular. This should not works if the parameter is categorical.
I hope the explanations are clear enough. Anyway, the modifications in the code are not complicated.