### PR TITLE
Fix parameter name in async example

### DIFF
--- a/examples/async_optimization.py
+++ b/examples/async_optimization.py
@@ -45,7 +45,7 @@ class BayesianOptimizationHandler(RequestHandler):
 
         try:
             self._bo.register(
-                x=body["params"],
+                params=body["params"],
                 target=body["target"],
             )
             print("BO has registered: {} points.".format(len(self._bo.space)), end="\n\n")


### PR DESCRIPTION
The async example was calling `register` with a parameter `x`, this is
the old style. This commit changes it to `params` fixing a bug.