### PR TITLE
Add long_description to README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Fernando Nogueira',
     author_email="fmfnogueira@gmail.com",
     description='Bayesian Optimization package',
+    long_description='A Python implementation of global optimization with gaussian processes.',
     download_url='https://github.com/fmfn/BayesianOptimization/tarball/0.6',
     install_requires=[
         "numpy >= 1.9.0",


### PR DESCRIPTION
This will stop the [PyPI page](https://pypi.org/project/bayesian-optimization/) looking bare with "The author of this package has not provided a project description."