### PR TITLE
Improve the Suggest-Evaluate-Register example

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ load_logs(new_optimizer, logs=["./logs.json"]);
 
 ## Next Steps
 
-This introduction covered the most basic functionality of the package. Checkout the `basic-tour` and `advanced-tour` notebooks in the example folder, yhere you will more detailed explanations and other more advanced functionality. Also, browse the examples folder for implementation tips and ideas.
+This introduction covered the most basic functionality of the package. Checkout the [basic-tour](https://github.com/fmfn/BayesianOptimization/blob/master/examples/basic-tour.ipynb) and [advanced-tour](https://github.com/fmfn/BayesianOptimization/blob/master/examples/advanced-tour.ipynb) notebooks in the example folder, where you will find detailed explanations and other more advanced functionality. Also, browse the examples folder for implementation tips and ideas.
 
 Installation
 ============

--- a/examples/advanced-tour.ipynb
+++ b/examples/advanced-tour.ipynb
@@ -35,10 +35,24 @@
    "source": [
     "# Let's start by definying our function, bounds, and instanciating an optimization object.\n",
     "def black_box_function(x, y):\n",
-    "    return -x ** 2 - (y - 1) ** 2 + 1\n",
-    "\n",
+    "    return -x ** 2 - (y - 1) ** 2 + 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that the evaluation of the blackbox function will NOT be carried out by the optimizer object. We are simulating a situation where this function could be being executed in a different machine, maybe it is written in another language, or it could even be the result of a chemistry experiment. Whatever the case may be, you can take charge of it and as long as you don't invoke the `probe` or `maximize` methods directly, the optimizer object will ignore the blackbox function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "optimizer = BayesianOptimization(\n",
-    "    f=black_box_function,\n",
+    "    f=None,\n",
     "    pbounds={'x': (-2, 2), 'y': (-3, 3)},\n",
     "    verbose=2,\n",
     "    random_state=1,\n",
@@ -54,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,14 +88,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Next point to probe is: {'x': -0.331911981189704, 'y': 1.3219469606529488}\n"
+      "Next point to probe is: {'y': 1.3219469606529488, 'x': -0.331911981189704}\n"
      ]
     }
    ],
@@ -99,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -124,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,19 +159,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-19.0 {'x': 2.0, 'y': -3.0}\n",
-      "-12.194801029414048 {'x': -1.2447710918286998, 'y': -2.412527795983739}\n",
-      "0.6381713808008993 {'x': -0.3395244574146384, 'y': 1.4965397889559267}\n",
-      "0.5052897389362041 {'x': -0.6435716330974743, 'y': 1.2837707069731576}\n",
-      "0.9493808230928116 {'x': -0.019453291773639306, 'y': 1.2241444765020055}\n",
-      "{'target': 0.9493808230928116, 'params': {'x': -0.019453291773639306, 'y': 1.2241444765020055}}\n"
+      "-19.0 {'y': -3.0, 'x': 2.0}\n",
+      "-12.194801029414048 {'y': -2.412527795983739, 'x': -1.2447710918286998}\n",
+      "0.6381713808008993 {'y': 1.4965397889559267, 'x': -0.3395244574146384}\n",
+      "0.5052897389362041 {'y': 1.2837707069731576, 'x': -0.6435716330974743}\n",
+      "0.9493808230928116 {'y': 1.2241444765020055, 'x': -0.019453291773639306}\n",
+      "{'target': 0.9493808230928116, 'params': {'y': 1.2241444765020055, 'x': -0.019453291773639306}}\n"
      ]
     }
    ],


### PR DESCRIPTION
This commit improves the Suggest-Evaluate-Register example by passing
no blackbox function to the optimizer making it clear it is not needed
in this scenario.