### PR TITLE
Added option to keep using an older log (Save -> Load -> Save)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ optimizer.maximize(
 )
 ```
 
+By default the previous data in the json file is removed. If you want to keep working with the same logger, the `reset` paremeter in `JSONLogger` should be set to False.
+
 ### 4.2 Loading progress
 
 Naturally, if you stored progress you will be able to load that onto a new instance of `BayesianOptimization`. The easiest way to do it is by invoking the `load_logs` function, from the `util` submodule.

--- a/bayes_opt/logger.py
+++ b/bayes_opt/logger.py
@@ -104,12 +104,13 @@ class ScreenLogger(_Tracker):
 
 
 class JSONLogger(_Tracker):
-    def __init__(self, path):
+    def __init__(self, path, reset=True):
         self._path = path if path[-5:] == ".json" else path + ".json"
-        try:
-            os.remove(self._path)
-        except OSError:
-            pass
+        if reset:
+            try:
+                os.remove(self._path)
+            except OSError:
+                pass
         super(JSONLogger, self).__init__()
 
     def update(self, event, instance):


### PR DESCRIPTION
Quick fix so that when loading a log file, the information it is not lost. Having an option to fix #159 easily. For backwards compatibility, reset is set to True. 