### PR TITLE
Check bounds_transformation is correct type

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -87,7 +87,11 @@ class BayesianOptimization(Observable):
         self._verbose = verbose
         self._bounds_transformer = bounds_transformer
         if self._bounds_transformer:
-            self._bounds_transformer.initialize(self._space)
+            try:
+                self._bounds_transformer.initialize(self._space)
+            except (AttributeError, TypeError):
+                raise AssertionError('The transformer must be instance of'
+                                     'DomainTransformer')
 
         super(BayesianOptimization, self).__init__(events=DEFAULT_EVENTS)
 

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -90,8 +90,8 @@ class BayesianOptimization(Observable):
             try:
                 self._bounds_transformer.initialize(self._space)
             except (AttributeError, TypeError):
-                raise AssertionError('The transformer must be instance of'
-                                     'DomainTransformer')
+                raise TypeError('The transformer must be an instance of '
+                                'DomainTransformer')
 
         super(BayesianOptimization, self).__init__(events=DEFAULT_EVENTS)
 

--- a/tests/test_bayesian_optimization.py
+++ b/tests/test_bayesian_optimization.py
@@ -157,6 +157,7 @@ def test_prime_subscriptions():
         ])
 
     test_subscriber = "test_subscriber"
+
     def test_callback(event, instance):
         pass
 
@@ -289,6 +290,13 @@ def test_maximize():
     assert tracker.start_count == 3
     assert tracker.step_count == 5
     assert tracker.end_count == 3
+
+
+def test_define_wrong_transformer():
+    with pytest.raises(AssertionError):
+        optimizer = BayesianOptimization(target_func, PBOUNDS,
+                                         random_state=np.random.RandomState(1),
+                                         bounds_transformer=3)
 
 
 if __name__ == '__main__':

--- a/tests/test_bayesian_optimization.py
+++ b/tests/test_bayesian_optimization.py
@@ -293,7 +293,7 @@ def test_maximize():
 
 
 def test_define_wrong_transformer():
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         optimizer = BayesianOptimization(target_func, PBOUNDS,
                                          random_state=np.random.RandomState(1),
                                          bounds_transformer=3)


### PR DESCRIPTION
A quick check following the 'don't ask for permission ask for forgiveness' motto to make sure that the bounds_transformer used can be called otherwise a clear exception message is shown.