### PR TITLE
Add virtual environments folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,12 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
Since it is best practice to create virtual environments for each python project. I've thought that it would be nice to have it on gitignore. 