### PR TITLE
Add license classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,7 @@ setup(
         "scipy >= 0.14.0",
         "scikit-learn >= 0.18.0",
     ],
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+    ]
 )


### PR DESCRIPTION
This PR adds a license classifier so that the correct license (MIT) appears in the [Python Package Index (PyPI) package overview](https://pypi.org/project/bayesian-optimization/). See [PyPI Classifiers List](https://pypi.org/classifiers/) for all possible classifiers.