### PR TITLE
docs: fix simple typo, provieded -> provided

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -79,7 +79,7 @@ class BayesianOptimization(Observable):
 
     random_state: int or numpy.random.RandomState, optional(default=None)
         If the value is an integer, it is used as the seed for creating a
-        numpy.random.RandomState. Otherwise the random state provieded it is used.
+        numpy.random.RandomState. Otherwise the random state provided it is used.
         When set to None, an unseeded random state is generated.
 
     verbose: int, optional(default=2)


### PR DESCRIPTION
There is a small typo in bayes_opt/bayesian_optimization.py.

Should read `provided` rather than `provieded`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md