### PR TITLE
2 typo fixes in advanced-tour.ipynb

### DIFF
--- a/examples/advanced-tour.ipynb
+++ b/examples/advanced-tour.ipynb
@@ -520,7 +520,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/examples/advanced-tour.ipynb
+++ b/examples/advanced-tour.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's start by definying our function, bounds, and instanciating an optimization object.\n",
+    "# Let's start by defining our function, bounds, and instanciating an optimization object.\n",
     "def black_box_function(x, y):\n",
     "    return -x ** 2 - (y - 1) ** 2 + 1"
    ]
@@ -298,7 +298,7 @@
    "source": [
     "### 3.1 Passing parameter to the GP\n",
     "\n",
-    "Depending on the problemn it could be beneficial to change the default parameters of the underlying GP. You can simply pass GP parameters to the maximize method directly as you can see below:"
+    "Depending on the problem it could be beneficial to change the default parameters of the underlying GP. You can simply pass GP parameters to the maximize method directly as you can see below:"
    ]
   },
   {
@@ -520,7 +520,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi, 

I just spotted simple typos while I ran advanced-tour.ipynb.

definying->defining, problemn->problem