### PR TITLE
Use enum in place of string for acquistion function

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -3,7 +3,7 @@ import warnings
 from .target_space import TargetSpace
 from .event import Events, DEFAULT_EVENTS
 from .logger import _get_default_logger
-from .util import UtilityFunction, acq_max, ensure_rng
+from .util import UtilityFunction, acq_max, ensure_rng, ACQ
 
 from sklearn.gaussian_process.kernels import Matern
 from sklearn.gaussian_process import GaussianProcessRegressor
@@ -207,7 +207,7 @@ class BayesianOptimization(Observable):
     def maximize(self,
                  init_points=5,
                  n_iter=25,
-                 acq='ucb',
+                 acq=ACQ.ucb,
                  kappa=2.576,
                  kappa_decay=1,
                  kappa_decay_delay=0,
@@ -227,7 +227,7 @@ class BayesianOptimization(Observable):
             Number of iterations where the method attempts to find the maximum
             value.
 
-        acq: {'ucb', 'ei', 'poi'}
+        acq: ACQ {ACQ.ucb, ACQ.ei, ACQ.poi}
             The acquisition method used.
                 * 'ucb' stands for the Upper Confidence Bounds method
                 * 'ei' is the Expected Improvement method

--- a/examples/async_optimization.py
+++ b/examples/async_optimization.py
@@ -37,7 +37,7 @@ class BayesianOptimizationHandler(RequestHandler):
         f=black_box_function,
         pbounds={"x": (-4, 4), "y": (-3, 3)}
     )
-    _uf = UtilityFunction(kind="ucb", kappa=3, xi=1)
+    _uf = UtilityFunction(kind=ACQ.ucb, kappa=3, xi=1)
 
     def post(self):
         """Deal with incoming requests."""

--- a/tests/test_bayesian_optimization.py
+++ b/tests/test_bayesian_optimization.py
@@ -82,7 +82,7 @@ def test_suggest_at_random():
 
 
 def test_suggest_with_one_observation():
-    util = UtilityFunction(kind="ucb", kappa=5, xi=0)
+    util = UtilityFunction(kind=ACQ.ucb, kappa=5, xi=0)
     optimizer = BayesianOptimization(target_func, PBOUNDS, random_state=1)
 
     optimizer.register(params={"p1": 1, "p2": 2}, target=3)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from bayes_opt import BayesianOptimization
 from bayes_opt.util import UtilityFunction, Colours
-from bayes_opt.util import acq_max, load_logs, ensure_rng
+from bayes_opt.util import acq_max, load_logs, ensure_rng, ACQ
 
 from sklearn.gaussian_process.kernels import Matern
 from sklearn.gaussian_process import GaussianProcessRegressor
@@ -39,7 +39,7 @@ def get_globals():
     return {'x': X, 'y': y, 'gp': GP, 'mesh': mesh}
 
 
-def brute_force_maximum(MESH, GP, kind='ucb', kappa=1.0, xi=1.0):
+def brute_force_maximum(MESH, GP, kind=ACQ.ucb, kappa=1.0, xi=1.0):
     uf = UtilityFunction(kind=kind, kappa=kappa, xi=xi)
 
     mesh_vals = uf.utility(MESH, GP, 2)
@@ -54,21 +54,30 @@ X, Y, GP, MESH = GLOB['x'], GLOB['y'], GLOB['gp'], GLOB['mesh']
 
 
 def test_utility_fucntion():
-    util = UtilityFunction(kind="ucb", kappa=1.0, xi=1.0)
-    assert util.kind == "ucb"
+    util = UtilityFunction(kind='ucb', kappa=1.0, xi=1.0)
+    assert util.kind == ACQ.ucb
+    
+    util = UtilityFunction(kind=ACQ.ucb, kappa=1.0, xi=1.0)
+    assert util.kind == ACQ.ucb
 
     util = UtilityFunction(kind="ei", kappa=1.0, xi=1.0)
-    assert util.kind == "ei"
+    assert util.kind == ACQ.ei
+
+    util = UtilityFunction(kind=ACQ.ei, kappa=1.0, xi=1.0)
+    assert util.kind == ACQ.ei
+
+    util = UtilityFunction(kind=ACQ.poi, kappa=1.0, xi=1.0)
+    assert util.kind == ACQ.poi
 
     util = UtilityFunction(kind="poi", kappa=1.0, xi=1.0)
-    assert util.kind == "poi"
+    assert util.kind == ACQ.poi
 
     with pytest.raises(NotImplementedError):
         util = UtilityFunction(kind="other", kappa=1.0, xi=1.0)
 
 
 def test_acq_with_ucb():
-    util = UtilityFunction(kind="ucb", kappa=1.0, xi=1.0)
+    util = UtilityFunction(kind=ACQ.ucb, kappa=1.0, xi=1.0)
     episilon = 1e-2
     y_max = 2.0
 
@@ -80,7 +89,7 @@ def test_acq_with_ucb():
         random_state=ensure_rng(0),
         n_iter=20
     )
-    _, brute_max_arg = brute_force_maximum(MESH, GP, kind='ucb', kappa=1.0, xi=1.0)
+    _, brute_max_arg = brute_force_maximum(MESH, GP, kind=ACQ.ucb, kappa=1.0, xi=1.0)
 
     assert all(abs(brute_max_arg - max_arg) < episilon)
 


### PR DESCRIPTION
Using enums instead of string is easier for command completion.
![image](https://user-images.githubusercontent.com/614215/108066911-4e6efd00-7060-11eb-80b4-3945141c6863.png)

Which avoids the error when typing  'pi'  instead of the correct 'poi'.

This implementation accepts both enum and strings and is thus backward compatible.

