### PR TITLE
print both digits of the exponent in scientific notation form for flo…

### DIFF
--- a/bayes_opt/logger.py
+++ b/bayes_opt/logger.py
@@ -30,12 +30,12 @@ class ScreenLogger(_Tracker):
 
     def _format_number(self, x):
         if isinstance(x, int):
-                s = "{x:< {s}}".format(
+                s = "{x:<{s}}".format(
                     x=x,
                     s=self._default_cell_size,
                 )
         else:
-            s = "{x:< {s}.{p}}".format(
+            s = "{x:<{s}.{p}}".format(
                 x=x,
                 s=self._default_cell_size,
                 p=self._default_precision,


### PR DESCRIPTION
…at parameters with values >= 10,000 in the ScreenLogger

An extraneous whitespace character in the string formatter for the ScreenLogger is causing the smaller of the two default scientific notation exponent digits in the number formatter for the parameters to be cut off for floats with values of 10,000.0 or more.  This only pertains to the current default cell size of 9 and default precision of 4.  The issue persists for other combinations of default cell size and default precisions whose difference is not in excess of 5 (one character for decimal, one for 'e', one for '+', and two for exponent).

current behavior:
```
default_cell_size = 9
default_precision = 4

def format_number(x):
    if isinstance(x, int):
        s = "{x:< {s}}".format(
            x=x,
            s=default_cell_size,
        )
    else:
        s = "{x:< {s}.{p}}".format(
            x=x,
            s=default_cell_size,
            p=default_precision,
        )

    if len(s) > default_cell_size:
        if "." in s:
            return s[:default_cell_size]
        else:
            return s[:default_cell_size - 3] + "..."
    return s

test_vals = [
    123, 123.45, 1234, 1234.5, 12345,
    12345.6789, 123456.78901, 123456789
]

for number in test_vals:
    print(format_number(number))
```

prints (with a leading white space):

```
 123     
 123.5   
 1234    
 1.234e+0
 12345   
 1.235e+0
 1.235e+0
 12345...
```

Dropping the extraneous white space retains both of the exponents digits:

```
default_cell_size = 9
default_precision = 4

def format_number(x):
    if isinstance(x, int):
        s = "{x:<{s}}".format(
            x=x,
            s=default_cell_size,
        )
    else:
        s = "{x:<{s}.{p}}".format(
            x=x,
            s=default_cell_size,
            p=default_precision,
        )

    if len(s) > default_cell_size:
        if "." in s:
            return s[:default_cell_size]
        else:
            return s[:default_cell_size - 3] + "..."
    return s

test_vals = [
    123, 123.45, 1234, 1234.5, 12345,
    12345.6789, 123456.78901, 123456789
]

for number in test_vals:
    print(format_number(number))
```

prints:

```
123      
123.5    
1234     
1.234e+03
12345    
1.235e+04
1.235e+05
123456789
```
