### PR TITLE
Fix acqusistion function bug when std output by GP is 0.0

### DIFF
--- a/bayes_opt/util.py
+++ b/bayes_opt/util.py
@@ -143,19 +143,28 @@ class UtilityFunction(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             mean, std = gp.predict(x, return_std=True)
-
+        val = None
         a = (mean - y_max - xi)
-        z = a / std
-        return a * norm.cdf(z) + std * norm.pdf(z)
+        with np.errstate(divide='ignore'):
+            z = a / std
+            val = a * norm.cdf(z) + std * norm.pdf(z)
+            val[std == 0.0] = 0.0
 
+        return val
+        
     @staticmethod
     def _poi(x, gp, y_max, xi):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             mean, std = gp.predict(x, return_std=True)
+        
+        val = None
+        with np.errstate(divide='ignore'):
+            z = (mean - y_max - xi)/std
+            val = norm.cdf(z)
+            val[std == 0.0] = 0.0
 
-        z = (mean - y_max - xi)/std
-        return norm.cdf(z)
+        return val
 
 
 class NotUniqueError(Exception):


### PR DESCRIPTION
In order to calculate the acquisition function  EI and PI for a given point x, we will use mean and std output by the gaussian process. However, std may be 0.0(e.g., the gaussian process will set std to 0.0 when we sample a point x that has been sampled before),  which will cause an error when calculating EI and PI. In function _ei, when std is 0.0, we can't calculate the EI value using `a * norm.cdf(z) + std * norm.pdf(z)`, instead, we should set the EI value to 0.0. So does function _poi.  Therefore, I changed function _ei and _poi to fix this bug.
I refer to [Acquisition functions in Bayesian Optimization](https://ekamperi.github.io/machine%20learning/2021/06/11/acquisition-functions.html), which discussed the acquisition function in detail and explained the derivation process of PI and EI

