### PR TITLE
Add `colorama` to fix colors on windows

### DIFF
--- a/bayes_opt/util.py
+++ b/bayes_opt/util.py
@@ -2,6 +2,7 @@ import warnings
 import numpy as np
 from scipy.stats import norm
 from scipy.optimize import minimize
+from colorama import just_fix_windows_console
 
 
 def acq_max(ac, gp, y_max, bounds, random_state, constraint=None, n_warmup=10000, n_iter=10):
@@ -295,3 +296,6 @@ class Colours:
     def yellow(cls, s):
         """Wrap text in yellow."""
         return cls._wrap_colour(s, cls.YELLOW)
+
+
+just_fix_windows_console()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "numpy >= 1.9.0",
         "scipy >= 1.0.0",
         "scikit-learn >= 0.18.0",
+        "colorama"
     ],
     classifiers=[
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
fix #208 

Optionally, we could also modify the code to use colorama's colours instead of a custom implementation.