### PR TITLE
Note minimum colorama version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "numpy >= 1.9.0",
         "scipy >= 1.0.0",
         "scikit-learn >= 0.18.0",
-        "colorama"
+        "colorama >= 0.4.6",
     ],
     classifiers=[
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
`colorama.just_fix_windows_console` was added in Colorama 0.4.6, so that's the minimum version.

(See https://stackoverflow.com/q/74654425/51685 for context.)