### PR TITLE
Allow saving and loading optimizer state without probes/registrations

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -352,19 +352,7 @@ class BayesianOptimization:
         ----------
         path : str or PathLike
             Path to save the optimization state
-
-        Raises
-        ------
-        ValueError
-            If attempting to save state before collecting any samples.
         """
-        if len(self._space) == 0:
-            msg = (
-                "Cannot save optimizer state before collecting any samples. "
-                "Please probe or register at least one point before saving."
-            )
-            raise ValueError(msg)
-
         random_state = None
         if self._random_state is not None:
             state_tuple = self._random_state.get_state()
@@ -443,7 +431,8 @@ class BayesianOptimization:
         # Set the GP parameters
         self.set_gp_params(**gp_params)
 
-        self._gp.fit(self._space.params, self._space.target)
+        if len(self._space):
+            self._gp.fit(self._space.params, self._space.target)
 
         if state["random_state"] is not None:
             random_state_tuple = (

--- a/tests/test_bayesian_optimization.py
+++ b/tests/test_bayesian_optimization.py
@@ -372,14 +372,16 @@ def test_save_load_unused_optimizer(tmp_path):
     """Test saving and loading optimizer state with unused optimizer."""
     optimizer = BayesianOptimization(f=target_func, pbounds=PBOUNDS, random_state=1, verbose=0)
 
-    # Test that saving without samples raises an error
-    with pytest.raises(ValueError, match="Cannot save optimizer state before collecting any samples"):
-        optimizer.save_state(tmp_path / "optimizer_state.json")
+    # Test that saving without samples does not raise an error
+    optimizer.save_state(tmp_path / "unprobed_optimizer_state.json")
 
-    # Add a sample point
+    # Check that we load the original state
+    first_suggestion = optimizer.suggest()
+    optimizer.load_state(tmp_path / "unprobed_optimizer_state.json")
+    assert optimizer.suggest() == first_suggestion
+
+    # Save an optimizer state with a probed point
     optimizer.probe(params={"p1": 1, "p2": 2}, lazy=False)
-
-    # Now saving should work
     optimizer.save_state(tmp_path / "optimizer_state.json")
 
     new_optimizer = BayesianOptimization(f=target_func, pbounds=PBOUNDS, random_state=1, verbose=0)


### PR DESCRIPTION
Closes #581 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Saving the optimizer state is now allowed even if no samples have been collected, without raising an error.
  * Loading an unused optimizer state no longer attempts to fit the model on empty data, preventing unnecessary errors.

* **Tests**
  * Updated tests to verify that saving and loading an unused optimizer state works correctly and maintains consistent suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->