### PR TITLE
Remove stale ndarray sorting warnings

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -12,7 +12,6 @@ from collections.abc import Iterable
 from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from warnings import warn
 
 import numpy as np
 from scipy.optimize import NonlinearConstraint
@@ -137,8 +136,6 @@ class BayesianOptimization:
                 msg = "The transformer must be an instance of DomainTransformer"
                 raise TypeError(msg)
             self._bounds_transformer.initialize(self._space)
-
-        self._sorting_warning_already_shown = False  # TODO: remove in future version
 
         # Initialize logger
         self.logger = ScreenLogger(verbose=self._verbose, is_constrained=self.is_constrained)
@@ -278,17 +275,6 @@ class BayesianOptimization:
         constraint_value: float or None
             Value of the constraint function at the observation, if any.
         """
-        # TODO: remove in future version
-        if isinstance(params, np.ndarray) and not self._sorting_warning_already_shown:
-            msg = (
-                "You're attempting to register an np.ndarray. In previous versions, the optimizer internally"
-                " sorted parameters by key and expected any registered array to respect this order."
-                " In the current and any future version the order as given by the pbounds dictionary will be"
-                " used. If you wish to retain sorted parameters, please manually sort your pbounds"
-                " dictionary before constructing the optimizer."
-            )
-            warn(msg, stacklevel=1)
-            self._sorting_warning_already_shown = True
         self._space.register(params, target, constraint_value)
         self.logger.log_optimization_step(
             self._space.keys, self._space.res()[-1], self._space.params_config, self.max
@@ -308,18 +294,6 @@ class BayesianOptimization:
             If True, the optimizer will evaluate the points when calling
             maximize(). Otherwise it will evaluate it at the moment.
         """
-        # TODO: remove in future version
-        if isinstance(params, np.ndarray) and not self._sorting_warning_already_shown:
-            msg = (
-                "You're attempting to register an np.ndarray. In previous versions, the optimizer internally"
-                " sorted parameters by key and expected any registered array to respect this order."
-                " In the current and any future version the order as given by the pbounds dictionary will be"
-                " used. If you wish to retain sorted parameters, please manually sort your pbounds"
-                " dictionary before constructing the optimizer."
-            )
-            warn(msg, stacklevel=1)
-            self._sorting_warning_already_shown = True
-            params = self._space.array_to_params(params)
         if lazy:
             self._queue.append(params)
         else:

--- a/tests/test_bayesian_optimization.py
+++ b/tests/test_bayesian_optimization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pickle
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -95,6 +96,28 @@ def test_register():
         optimizer.register(params={"p1": 1, "p2": 2}, target=3)
     with pytest.raises(NotUniqueError):
         optimizer.register(params={"p1": 5, "p2": 4}, target=9)
+
+
+def test_register_array_uses_pbounds_order_without_warning():
+    optimizer = BayesianOptimization(target_func, {"p1": (0, 10), "p2": (0, 10)}, random_state=1)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        optimizer.register(params=np.array([1, 2]), target=3)
+
+    assert caught == []
+    assert optimizer.space.array_to_params(optimizer.space.params[0]) == {"p1": 1.0, "p2": 2.0}
+
+
+def test_probe_array_uses_pbounds_order_without_warning():
+    optimizer = BayesianOptimization(target_func, {"p1": (0, 10), "p2": (0, 10)}, random_state=1)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        optimizer.probe(params=np.array([1, 2]), lazy=False)
+
+    assert caught == []
+    assert optimizer.space.array_to_params(optimizer.space.params[0]) == {"p1": 1.0, "p2": 2.0}
 
 
 def test_probe_lazy():


### PR DESCRIPTION
Remove the old ndarray sorting warning now that pbounds order is the canonical order. Add regression tests for register/probe with ndarray inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary warnings when registering or probing with NumPy arrays.

* **Tests**
  * Added tests verifying NumPy array inputs work correctly and parameters properly map to bounds order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->