### PR TITLE
Add `alpha` to args

### DIFF
--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -69,6 +69,11 @@ class BayesianOptimization:
         numpy.random.RandomState. Otherwise the random state provided is used.
         When set to None, an unseeded random state is generated.
 
+    alpha: float, optional(default=1e-6)
+        Regularization parameter to prevent numerical issues or to adjust to an
+        error gaussian distribution with high variance. The higher, the higher
+        the regularization.
+
     verbose: int, optional(default=2)
         The level of verbosity.
 
@@ -89,6 +94,7 @@ class BayesianOptimization:
         acquisition_function: AcquisitionFunction | None = None,
         constraint: NonlinearConstraint | None = None,
         random_state: int | RandomState | None = None,
+        alpha: float = 1e-6,
         verbose: int = 2,
         bounds_transformer: DomainTransformer | None = None,
         allow_duplicate_points: bool = False,
@@ -123,7 +129,7 @@ class BayesianOptimization:
         # Internal GP regressor
         self._gp = GaussianProcessRegressor(
             kernel=wrap_kernel(Matern(nu=2.5), transform=self._space.kernel_transform),
-            alpha=1e-6,
+            alpha=alpha,
             normalize_y=True,
             n_restarts_optimizer=5,
             random_state=self._random_state,


### PR DESCRIPTION
In [Gaussian Processes for Machine Learning book](https://gaussianprocess.org/gpml/chapters/RW.pdf) Chapter 2.2's Algorithm 2.1 presents the algorithm used by Scikit Learn of Gaussian Process. There appears a term $\sigma^2$ that accounts for assuming high variance in the errors. Scikit learn defaulted that to `1e-10` and you choose a magic number of `1e-6`. I think it's enough motivated to pass the election of that parameter (Scikit call it `alpha`) to the user.

Chapter 6 of that book talks about regularization and [here](https://scikit-learn.org/stable/auto_examples/gaussian_process/plot_gpr_noisy_targets.html#sphx-glr-auto-examples-gaussian-process-plot-gpr-noisy-targets-py) Scikit has a motivating example of its usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gaussian Process regularization can now be customized when initializing the optimizer. The alpha parameter is now configurable, allowing users to fine-tune model behavior while maintaining backward compatibility with the default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->