### PR TITLE
fix: gphedge duplicates

### DIFF
--- a/bayes_opt/acquisition.py
+++ b/bayes_opt/acquisition.py
@@ -1316,6 +1316,15 @@ class GPHedge(AcquisitionFunction):
         ]
         self.previous_candidates = np.array(x_max)
         idx = self._sample_idx_from_softmax_gains(random_state=random_state)
+        if not target_space._allow_duplicate_points and x_max[idx] in target_space:
+            # If every candidate is a duplicate, keep the original choice.
+            # Avoiding duplicates then requires generating new candidates, which
+            # is outside GPHedge's candidate-selection responsibility.
+            non_duplicate_idx = [idx for idx, x in enumerate(x_max) if x not in target_space]
+            if len(non_duplicate_idx) > 0:
+                cumsum_softmax_g = np.cumsum(softmax(self.gains[non_duplicate_idx]))
+                r = random_state.rand()
+                idx = non_duplicate_idx[np.argmax(r <= cumsum_softmax_g)]
         return x_max[idx]
 
     def get_acquisition_params(self) -> dict[str, Any]:

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -69,6 +69,23 @@ def constrained_target_space(target_func):
     )
 
 
+class FixedSuggestion(acquisition.AcquisitionFunction):
+    def __init__(self, suggestion):
+        super().__init__()
+        self.suggestion = np.array(suggestion)
+
+    def suggest(self, *args, **kwargs):
+        return self.suggestion
+
+    def base_acq(self, mean, std):
+        return mean
+
+    def get_acquisition_params(self):
+        return {}
+
+    def set_acquisition_params(self, params): ...
+
+
 class MockAcquisition(acquisition.AcquisitionFunction):
     def __init__(self):
         super().__init__()
@@ -353,6 +370,19 @@ def test_gphedge_softmax_sampling(random_state):
         acq.previous_candidates = np.zeros(len(base_acquisitions))
         acq._update_gains(MockGP2(good_index=good_index))
         assert good_index == acq._sample_idx_from_softmax_gains(random_state=random_state)
+
+
+def test_gphedge_skips_duplicate_candidate_when_unique_candidate_exists(gp, target_space, random_state):
+    duplicate = np.array([2.5, 0.5])
+    unique = np.array([3.0, 1.0])
+    target_space.register(duplicate, target=sum(duplicate))
+
+    acq = acquisition.GPHedge(base_acquisitions=[FixedSuggestion(duplicate), FixedSuggestion(unique)])
+    acq.gains = np.array([100.0, 0.0])
+
+    suggestion = acq.suggest(gp=gp, target_space=target_space, fit_gp=False, random_state=random_state)
+
+    np.testing.assert_array_equal(suggestion, unique)
 
 
 def test_gphedge_integration(gp, target_space, random_state):


### PR DESCRIPTION
 While preparing the Python 3.14t support PR, I found a case where `GPHedge` can select an already registered boundary point with the newer numerical dependency stack.

 `GPHedge` selects one candidate from multiple base acquisition functions using a softmax over gains, but the previous implementation did not check whether the selected candidate was already registered. As a result, it could return a duplicate candidate even when another base acquisition had produced a fresh one.

 This did not show up in the existing test environment because the short seeded loop did not select a duplicate candidate there. However, GP/acquisition optimization results can vary across dependency versions, and the newer stack exposed this latent bug.

 When duplicate points are disabled, such a candidate raises `NotUniqueError` if passed directly to `register()`. Even through the public `probe()` path, it wastes an optimization iteration because no new observation is added.

Without this PR, supporting Python 3.14t requires a test-only change to `test_gphedge_integration`, because the newer dependency stack selects a duplicate `GPHedge` suggestion in that test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GPHedge now properly skips duplicate candidates when duplicates are forbidden, resampling from unique candidates to avoid returning previously registered points.

* **Tests**
  * Added test case validating duplicate candidate handling in GPHedge acquisition function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->