### PR TITLE
chore: update ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
     "pre-commit>=3.7.1",
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
-    "ruff>=0.12.3",
+    "ruff>=0.15.6",
     "sphinx-immaterial>=0.12.0",
     "sphinx>=7.0.0; python_version<'3.10'",
     "sphinx>=8.0.0; python_version>='3.10'",

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 
 import numpy as np
@@ -373,14 +374,14 @@ def test_gphedge_integration(gp, target_space, random_state):
 
 @pytest.mark.parametrize("kappa", [-1.0, -sys.float_info.epsilon, -np.inf])
 def test_upper_confidence_bound_invalid_kappa_error(kappa: float):
-    with pytest.raises(ValueError, match="kappa must be greater than or equal to 0."):
+    with pytest.raises(ValueError, match=re.escape("kappa must be greater than or equal to 0.")):
         acquisition.UpperConfidenceBound(kappa=kappa)
 
 
 @pytest.mark.parametrize("exploration_decay", [-0.1, 0.0, 1.1, 2.0, np.inf])
 def test_upper_confidence_bound_invalid_exploration_decay_error(exploration_decay: float):
     with pytest.raises(
-        ValueError, match="exploration_decay must be greater than 0 and less than or equal to 1."
+        ValueError, match=re.escape("exploration_decay must be greater than 0 and less than or equal to 1.")
     ):
         acquisition.UpperConfidenceBound(kappa=1.0, exploration_decay=exploration_decay)
 
@@ -388,21 +389,21 @@ def test_upper_confidence_bound_invalid_exploration_decay_error(exploration_deca
 @pytest.mark.parametrize("exploration_decay_delay", [-1, -10, "not_an_int", 1.5])
 def test_upper_confidence_bound_invalid_exploration_decay_delay_error(exploration_decay_delay):
     with pytest.raises(
-        ValueError, match="exploration_decay_delay must be an integer greater than or equal to 0."
+        ValueError, match=re.escape("exploration_decay_delay must be an integer greater than or equal to 0.")
     ):
         acquisition.UpperConfidenceBound(kappa=1.0, exploration_decay_delay=exploration_decay_delay)
 
 
 @pytest.mark.parametrize("xi", [-0.1, -1.0, -np.inf])
 def test_probability_of_improvement_invalid_xi_error(xi: float):
-    with pytest.raises(ValueError, match="xi must be greater than or equal to 0."):
+    with pytest.raises(ValueError, match=re.escape("xi must be greater than or equal to 0.")):
         acquisition.ProbabilityOfImprovement(xi=xi)
 
 
 @pytest.mark.parametrize("exploration_decay", [-0.1, 0.0, 1.1, 2.0, np.inf])
 def test_probability_of_improvement_invalid_exploration_decay_error(exploration_decay: float):
     with pytest.raises(
-        ValueError, match="exploration_decay must be greater than 0 and less than or equal to 1."
+        ValueError, match=re.escape("exploration_decay must be greater than 0 and less than or equal to 1.")
     ):
         acquisition.ProbabilityOfImprovement(xi=0.01, exploration_decay=exploration_decay)
 
@@ -410,21 +411,21 @@ def test_probability_of_improvement_invalid_exploration_decay_error(exploration_
 @pytest.mark.parametrize("exploration_decay_delay", [-1, -10, "not_an_int", 1.5])
 def test_probability_of_improvement_invalid_exploration_decay_delay_error(exploration_decay_delay):
     with pytest.raises(
-        ValueError, match="exploration_decay_delay must be an integer greater than or equal to 0."
+        ValueError, match=re.escape("exploration_decay_delay must be an integer greater than or equal to 0.")
     ):
         acquisition.ProbabilityOfImprovement(xi=0.01, exploration_decay_delay=exploration_decay_delay)
 
 
 @pytest.mark.parametrize("xi", [-0.1, -1.0, -np.inf])
 def test_expected_improvement_invalid_xi_error(xi: float):
-    with pytest.raises(ValueError, match="xi must be greater than or equal to 0."):
+    with pytest.raises(ValueError, match=re.escape("xi must be greater than or equal to 0.")):
         acquisition.ExpectedImprovement(xi=xi)
 
 
 @pytest.mark.parametrize("exploration_decay", [-0.1, 0.0, 1.1, 2.0, np.inf])
 def test_expected_improvement_invalid_exploration_decay_error(exploration_decay: float):
     with pytest.raises(
-        ValueError, match="exploration_decay must be greater than 0 and less than or equal to 1."
+        ValueError, match=re.escape("exploration_decay must be greater than 0 and less than or equal to 1.")
     ):
         acquisition.ExpectedImprovement(xi=0.01, exploration_decay=exploration_decay)
 
@@ -432,7 +433,7 @@ def test_expected_improvement_invalid_exploration_decay_error(exploration_decay:
 @pytest.mark.parametrize("exploration_decay_delay", [-1, -10, "not_an_int", 1.5])
 def test_expected_improvement_invalid_exploration_decay_delay_error(exploration_decay_delay):
     with pytest.raises(
-        ValueError, match="exploration_decay_delay must be an integer greater than or equal to 0."
+        ValueError, match=re.escape("exploration_decay_delay must be an integer greater than or equal to 0.")
     ):
         acquisition.ExpectedImprovement(xi=0.01, exploration_decay_delay=exploration_decay_delay)
 

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import numpy as np
 import pytest
 from scipy.optimize import NonlinearConstraint
@@ -163,5 +165,5 @@ def test_lower_less_than_upper(target_function):
 
 def test_null_constraint_function():
     constraint = ConstraintModel(None, np.array([0, 0]), np.array([1, 1]))
-    with pytest.raises(ValueError, match="No constraint function was provided."):
+    with pytest.raises(ValueError, match=re.escape("No constraint function was provided.")):
         constraint.eval()

--- a/tests/test_target_space.py
+++ b/tests/test_target_space.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import numpy as np
 import pytest
 from scipy.optimize import NonlinearConstraint
@@ -358,7 +360,7 @@ def test_set_bounds():
 
 def test_no_target_func():
     target_space = TargetSpace(None, PBOUNDS)
-    with pytest.raises(ValueError, match="No target function has been provided."):
+    with pytest.raises(ValueError, match=re.escape("No target function has been provided.")):
         target_space.probe({"p1": 1, "p2": 2})
 
 


### PR DESCRIPTION
Updated Ruff to 0.15.6 and fixed the RUF043 violations now enforced as a stable rule.
The rule existed in the previous Ruff version, but CI did not catch it because it was still preview-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency for code quality and linting tools to version 0.15.6 or higher.

* **Tests**
  * Improved parameter validation tests with enhanced error message assertions using more robust pattern matching across multiple test modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->